### PR TITLE
build 1.0.7

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "langdetect" %}
-{% set version = "1.0.9" %}
+{% set version = "1.0.7" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,16 +10,14 @@ source:
   sha256: cbc1fef89f8d062739774bd51eda3da3274006b3661d199c2655f6b3f6d605a0
 
 build:
-  number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
   run:
-    - python >=3.6
+    - python
     - six
 
 test:
@@ -33,10 +31,11 @@ test:
 
 about:
   home: https://github.com/Mimino666/langdetect
-  license_file: LICENSE
+  summary: Language detection library ported from Google's language-detection.
+  description: Port of Nakatani Shuyo's language-detection library (version from 03/03/2014) to Python.
   license: Apache-2.0
   license_family: Apache
-  summary: Language detection library ported from Google's language-detection.
+  license_file: LICENSE
   doc_url: https://github.com/Mimino666/langdetect
   dev_url: https://github.com/Mimino666/langdetect
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 source:
   # standard pypi url for 1.0.7 is missing
   url: https://files.pythonhosted.org/packages/59/59/4bc44158a767a6d66de18c4136c8aa90491d56cc951c10b74dd1e13213c9/langdetect-1.0.7.zip
-  sha256: cbc1fef89f8d062739774bd51eda3da3274006b3661d199c2655f6b3f6d605a0
+  sha256: 91a170d5f0ade380db809b3ba67f08e95fe6c6c8641f96d67a51ff7e98a9bf30
 
 build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  # standard pypi url for 1.0.7 is missing
+  url: https://files.pythonhosted.org/packages/59/59/4bc44158a767a6d66de18c4136c8aa90491d56cc951c10b74dd1e13213c9/langdetect-1.0.7.zip
   sha256: cbc1fef89f8d062739774bd51eda3da3274006b3661d199c2655f6b3f6d605a0
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   # standard pypi url for 1.0.7 is missing
-  url: https://files.pythonhosted.org/packages/59/59/4bc44158a767a6d66de18c4136c8aa90491d56cc951c10b74dd1e13213c9/langdetect-1.0.7.zip
+  url: https://pypi.io/packages/source/l/langdetect/langdetect-1.0.7.zip
   sha256: 91a170d5f0ade380db809b3ba67f08e95fe6c6c8641f96d67a51ff7e98a9bf30
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,11 +11,14 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  number: 0
 
 requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
     - six


### PR DESCRIPTION
langdetect 1.0.7 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-3779]
- [Upstream repository](https://github.com/Mimino666/langdetect/tree/master)

### Explanation of changes:

- not building latest because this version is needed in [PR](https://github.com/AnacondaRecipes/spacy-langdetect-feedstock/pull/1)


[PKG-3779]: https://anaconda.atlassian.net/browse/PKG-3779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ